### PR TITLE
fix: invert GPIO logic for hardware inverter component

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -5,7 +5,7 @@
 #include <preferences.h>
 
 using namespace std;
-#define CONFIG_CB5_SOFTWARE_VERSION "2.2.0"
+#define CONFIG_CB5_SOFTWARE_VERSION "2.2.1"
 
 #define CONFIG_SERIAL_BAUD_RATE 115200
 #define CONFIG_GPS_MAX_SETUP_VALID_DATA_RETRIES 60

--- a/src/domain/poisonAplicator/poison-applicator.cpp
+++ b/src/domain/poisonAplicator/poison-applicator.cpp
@@ -24,23 +24,23 @@ PoisonApplicator::PoisonApplicator()
 
 void PoisonApplicator::spin()
 {
-    this->_sys->setPort(this->_motorPort, HIGH);
+    this->_sys->setPort(this->_motorPort, LOW);
 };
 
 bool PoisonApplicator::readSensor()
 {
     bool result = this->_sys->readDigitalPort(this->_sensorPort) ? true : false;
-    return result;
+    return !result;
 };
 
 void PoisonApplicator::stop()
 {
-    this->_sys->setPort(this->_motorPort, LOW);
+    this->_sys->setPort(this->_motorPort, HIGH);
 }
 
 bool PoisonApplicator::isConnected()
 {
-    return !this->_sys->readDigitalPort(this->_connectionSensorPort);
+    return this->_sys->readDigitalPort(this->_connectionSensorPort);
 }
 
 unsigned char PoisonApplicator::getMotorPort() { return this->_motorPort; }


### PR DESCRIPTION
- Remove software inversion from connectivity sensors (prevent double inversion)
- Add software inversion to dose sensors (compensate for hardware inversion)
- Swap motor control HIGH/LOW signals (compensate for hardware inversion)

Fixes system malfunction caused by hardware inverter component that inverts all GPIO input and output signals on the ESP32 WROOM-32U.